### PR TITLE
Add multithreading to all servers

### DIFF
--- a/httpserver.py
+++ b/httpserver.py
@@ -1,7 +1,11 @@
-from handlers.httphandler import *
 from http.server import HTTPServer
+from socketserver import ThreadingMixIn
+from handlers.httphandler import *
 
-httpserv = HTTPServer((SERVER_ADDR, 80), CustomHandler)
+class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
+    pass
+
+httpserv = ThreadedHTTPServer((SERVER_ADDR, 80), CustomHandler)
 httpserv.timeout = 5
 
 print("Starting HTTP server...")

--- a/shttpserver.py
+++ b/shttpserver.py
@@ -8,7 +8,7 @@ import rsa
 
 import socket
 import traceback
-from socketserver import BaseRequestHandler, TCPServer
+from socketserver import BaseRequestHandler, TCPServer, ThreadingMixIn
 from random import randrange
 from base64 import b64decode
 
@@ -202,9 +202,9 @@ class CustomHandler(BaseRequestHandler):
                             except Exception as e:
                                 d = None
                         timeout += 1
-                        if timeout>=50:
+                        if timeout>=5000:
                             break
-                        time.sleep(0.1)
+                        time.sleep(0.001)
                     return False
                 else:
                     self.underlying = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -275,8 +275,10 @@ class CustomHandler(BaseRequestHandler):
             except Exception as e:
                 traceback.print_exc()
 
-shttpserv = TCPServer((SERVER_ADDR, 443), CustomHandler)
-shttpserv.timeout = 5
+class ThreadedTCPServer(ThreadingMixIn, TCPServer):
+    pass
+
+shttpserv = ThreadedTCPServer((SERVER_ADDR, 443), CustomHandler)
 
 print("Starting HTTPS server...")
 shttpserv.serve_forever()

--- a/shttpserver2.py
+++ b/shttpserver2.py
@@ -1,8 +1,13 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from socketserver import ThreadingMixIn
 from handlers.httphandler import *
-from http.server import HTTPServer
 import ssl
 
-shttpserv = HTTPServer((SERVER_ADDR, 8686), CustomHandler)
+class ThreadedHTTPSServer(ThreadingMixIn, HTTPServer):
+    """Handle requests in a separate thread for HTTPS."""
+
+shttpserv = ThreadedHTTPSServer((SERVER_ADDR, 8686), CustomHandler)
+shttpserv.timeout = 5
 
 context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
 context.load_cert_chain(certfile='cert/other/cert.pem', keyfile='cert/other/key.pem')

--- a/tcpserver.py
+++ b/tcpserver.py
@@ -1,6 +1,11 @@
 from handlers.tcphandler import *
+from socketserver import ThreadingMixIn
 
-tcpserv = TCPServer((SERVER_ADDR, 29900), CustomHandler)
+class ThreadedTCPServer(ThreadingMixIn, TCPServer):
+    pass
+
+tcpserv = ThreadedTCPServer((SERVER_ADDR, 29900), CustomHandler)
+tcpserv.timeout = 5
 
 print("Starting TCP server...")
 tcpserv.serve_forever()

--- a/tcpserver2.py
+++ b/tcpserver2.py
@@ -1,10 +1,16 @@
 from handlers.tcphandler import *
+from socketserver import ThreadingMixIn
 
 def idle(obj):
     return
 
 CustomHandler.requestchallenge = idle
-tcpserv = TCPServer((SERVER_ADDR, 29901), CustomHandler)
+
+class ThreadedTCPServer(ThreadingMixIn, TCPServer):
+    pass
+
+tcpserv = ThreadedTCPServer((SERVER_ADDR, 29901), CustomHandler)
+tcpserv.timeout = 5
 
 print("Starting TCP2 server...")
 tcpserv.serve_forever()

--- a/udpserver.py
+++ b/udpserver.py
@@ -1,4 +1,4 @@
-from socketserver import DatagramRequestHandler, UDPServer
+from socketserver import DatagramRequestHandler, UDPServer, ThreadingMixIn
 from random import randrange, choice
 from base64 import b64decode, b64encode
 from hashlib import md5
@@ -35,8 +35,12 @@ class CustomHandler(DatagramRequestHandler):
             self.wfile.write(b'\xfe\xfd\x0a')
             self.wfile.write(cid.to_bytes(4, 'big'))
             self.wfile.write(bytes(11))
-            
-udpserv = UDPServer((SERVER_ADDR, 27900), CustomHandler)
+
+class ThreadedUDPServer(ThreadingMixIn, UDPServer):
+    pass
+
+udpserv = ThreadedUDPServer((SERVER_ADDR, 27900), CustomHandler)
+udpserv.timeout = 5
 
 print("Starting UDP server...")
 udpserv.serve_forever()


### PR DESCRIPTION
Improves performance and prevents requests from stalling while the server is connected to another host.